### PR TITLE
Fix crash on wentForeground

### DIFF
--- a/src/ios/CDVAudioInputCapture.m
+++ b/src/ios/CDVAudioInputCapture.m
@@ -162,7 +162,8 @@
 
 - (void)willEnterForeground
 {
-    [self.audioReceiver start];
+    // this line causes app crash when audio input starts after app went foreground
+    // [self.audioReceiver start];
 }
 
 @end


### PR DESCRIPTION
This fixes app crash when ```audioinput.start()``` is called after app went foreground